### PR TITLE
Include Amazon Linux 2 case

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,9 +4,19 @@ class influxdb::install {
   if $::influxdb::manage_repo {
     case $facts['os']['family'] {
       'RedHat': {
+        case $facts['os']['name'] {
+          'Amazon': {
+            $name_os = 'rhel'
+            $maj_rel = '7'
+          }
+          default: {
+            $name_os = 'centos'
+            $maj_rel = $facts['operatingsystemmajrelease']
+          }
+        }
         yumrepo {
           'InfluxDB':
-            baseurl  => "${influxdb::repo_url}/centos/${facts['operatingsystemmajrelease']}/${facts['architecture']}/stable",
+            baseurl  => "${influxdb::repo_url}/${name_os}/${maj_rel}/${facts['architecture']}/stable",
             gpgcheck => true,
             gpgkey   => $influxdb::repo_keyurl,
             before   => Package['influxdb'];
@@ -36,3 +46,4 @@ class influxdb::install {
 
   ensure_packages(['influxdb'])
 }
+


### PR DESCRIPTION
Hi!
This modification is to include a special case with Linux Amazon 2
But the factor shows the following:

[root@grafana ~]# facter os
{
  architecture => "x86_64",
  family => "RedHat",
  hardware => "x86_64",
  name => "Amazon",
  release => {
    full => "2",
    major => "2"
  },
  selinux => {
    enabled => false
  }
}

Where is not really the version of my current machine and try to use the url from a version 2 of centos!

I tested this modification locally and run well!

Thx for share your code!
Fernando